### PR TITLE
Switch to ~./local/share/applications for appPath.

### DIFF
--- a/directories.js
+++ b/directories.js
@@ -47,10 +47,16 @@ platform.darwin = {
 platform.linux = {
   filePath: [
     path.join(os.homedir()),
+    path.join(os.homedir(), 'Documents'),
+    path.join(os.homedir(), 'Downloads'),
+    path.join(os.homedir(), 'Desktop'),
+    path.join(os.homedir(), 'Videos'),
+    path.join(os.homedir(), 'Music'),
+    path.join(os.homedir(), 'Pictures'),
     path.join('/', 'usr', 'bin'),
   ],
   appPath: [
-    path.join(os.homedir()),
+    path.join(os.homedir(), '.local', 'share', 'applications'),
     path.join('/', 'usr', 'bin'),
     path.join('/', 'opt'),
   ],

--- a/directories.js
+++ b/directories.js
@@ -47,12 +47,6 @@ platform.darwin = {
 platform.linux = {
   filePath: [
     path.join(os.homedir()),
-    path.join(os.homedir(), 'Documents'),
-    path.join(os.homedir(), 'Downloads'),
-    path.join(os.homedir(), 'Desktop'),
-    path.join(os.homedir(), 'Videos'),
-    path.join(os.homedir(), 'Music'),
-    path.join(os.homedir(), 'Pictures'),
     path.join('/', 'usr', 'bin'),
   ],
   appPath: [


### PR DESCRIPTION
Add ~./local/share/applications to appPath instead of home directory (suddenly I realize why the home directory was left out to begin with). Indexing the home directory in the appPath results in sluggish searches and is probably overkill.