### PR TITLE
Add support for abbreviation app name

### DIFF
--- a/lib/filterSort.js
+++ b/lib/filterSort.js
@@ -1,8 +1,31 @@
+// Function to map string like "Visual Studio Code" to "vsc"
+const toStartWord = str => str.split(" ").map(word => word[0]).join("").toLowerCase()
+
 module.exports = (query, items, accessor) => {
   const regex = new RegExp('\\b' + query, 'i')
   return items.reduce((memo, item) => {
-    const match = accessor(item).match(regex)
-    match && memo.push({ index: match.index, raw: item })
+    let ifMatch = isMatch => isMatch && memo.push({ index: 1, raw: item })
+    
+    // Try to match some full word (query "Store" will match "App Store")
+    let matchSomeWord = accessor(item).match(regex)
+    matchSomeWord && memo.push({ index: matchSomeWord.index, raw: item })
+    if (matchSomeWord) return memo
+
+    // Try to match each start alphabet in each word(query "as" will match "Android Studio")
+    let matchStartWord = toStartWord(item.title) === query.toLowerCase()
+    ifMatch(matchStartWord)
+    if (matchStartWord) return memo
+
+    // Some app like Vitual Studio Code, item.title will be only "Code" 
+    // but we want to match its full app name "Vitual Studio Code.app"
+
+    // Try to match each start alphabet in each word(query "vsc" will match "Vitual Studio Code.app")
+    let fullAppname = item.value.split("/")
+    console.log(fullAppname[fullAppname.length - 1].toLowerCase())
+  let matchAppFullName = toStartWord(fullAppname[fullAppname.length - 1]).includes(query.toLowerCase())
+    ifMatch(matchAppFullName)
+    if (matchAppFullName) return memo
+
     return memo
   }, []).sort((a, b) => {
     return a.start > b.start ? -1 : 1

--- a/test/appFinder.spec.js
+++ b/test/appFinder.spec.js
@@ -26,6 +26,13 @@ const collection = [
     value: '/Applications/Utility/Terminal.app',
     id: '/Applications/Utility/Terminal.app',
   },
+  {
+    icon: 'fa-file',
+    title: 'Code',
+    subtitle: '/Applications/Vitual Studio Code.app',
+    value: '/Applications/Vitual Studio Code.app',
+    id: '/Applications/Vitual Studio Code.app',
+  }
 ]
 
 const appFinder = require('../appFinder')
@@ -65,4 +72,9 @@ describe('Works with space in query', function (assert) {
 describe('Works with dots and dashes', function (assert) {
   assert.plan(1)
   assert.ok(appFinder({cwd: ''}).respondsTo('some-magic.'))
+})
+
+describe('Works with abbreviations', function (assert) {
+  assert.plan(1)
+  assert.ok(appFinder({cwd: ''}).respondsTo('vsc'))
 })


### PR DESCRIPTION
Add ability to search app with abbreviation name. Such as query "as" will be match "Android Studio".

Also support some app that title difference from its *.app like Virtual Studio Code that come with title "Code" with filename "Virtual Studio Code.app" can be search by the query "vsc"