### PR TITLE
Fix issue with not being able to find apps on mac.

### DIFF
--- a/lib/file.js
+++ b/lib/file.js
@@ -46,7 +46,7 @@ class File {
   isDirectory () {
     const isDirectory = this.stats.isDirectory()
     const isSymbolicLink = this.stats.isSymbolicLink()
-    return isDirectory && !isSymbolicLink
+    return isDirectory && !isSymbolicLink && !this.isApp()
   }
 
   isBroken () {


### PR DESCRIPTION
Mac apps are `.app` and are also directories.

cc: @JeroenBoersma