### PR TITLE
Use windows shortcuts instead of executables

### DIFF
--- a/directories.js
+++ b/directories.js
@@ -7,11 +7,7 @@ platform.win32 = {
   filePath: [
     path.join(os.homedir()),
   ],
-  appPath: [
-    path.join(process.env.USERPROFILE, 'Desktop'),
-    path.join(process.env.APPDATA, 'Microsoft', 'Windows', 'Start Menu', 'Programs'),
-    path.join(process.env.ProgramData, 'Microsoft', 'Windows', 'Start Menu', 'Programs'),
-  ],
+  appPath: [],
   excludePath: [],
   excludeName: [
     'node_modules',
@@ -21,6 +17,20 @@ platform.win32 = {
     'tags',
     'log',
   ],
+}
+
+if (process.platform === 'win32') {
+  if (process.env.USERPROFILE) {
+    platform.win32.appPath.push(path.join(process.env.USERPROFILE, 'Desktop'))
+  }
+
+  if (process.env.APPDATA) {
+    platform.win32.appPath.push(path.join(process.env.APPDATA, 'Microsoft', 'Windows', 'Start Menu', 'Programs'))
+  }
+
+  if (process.env.ProgramData) {
+    platform.win32.appPath.push(path.join(process.env.ProgramData, 'Microsoft', 'Windows', 'Start Menu', 'Programs'))
+  }
 }
 
 platform.darwin = {

--- a/directories.js
+++ b/directories.js
@@ -8,8 +8,9 @@ platform.win32 = {
     path.join(os.homedir()),
   ],
   appPath: [
-    path.join('C:', 'Program Files (x86)'),
-    path.join('C:', 'Program Files'),
+    path.join(process.env.USERPROFILE, 'Desktop'),
+    path.join(process.env.APPDATA, 'Microsoft', 'Windows', 'Start Menu', 'Programs'),
+    path.join(process.env.ProgramData, 'Microsoft', 'Windows', 'Start Menu', 'Programs'),
   ],
   excludePath: [],
   excludeName: [

--- a/lib/file.js
+++ b/lib/file.js
@@ -34,7 +34,7 @@ class File {
       return false
     }
 
-    return !!this.name.match(/\.(exe)$/)
+    return !!this.name.match(/\.(lnk)$/)
   }
 
   isAppLinux () {


### PR DESCRIPTION
In Windows it is normal to launch apps via shortcuts (.lnk) that reside in the users desktop or the start menu rather than the executable files (.exe) that reside in the program files directories.

The program files directories contain many executable's that are not suitable for end user launching.

Also many apps should always be launched via their shortcuts which often require arguments and a configured working directory.

For and example the Atom editor has the following in its shortcut:

C:\Program Files\Atom\Update.exe --processStart atom.exe

This triggers an update check for Atom at every launch, running atom.exe directly would bypass the update checks.

This change is to enumerate .lnk files in the following directories:
%USERPROFILE%\Desktop
%APPDATA%\Microsoft\Windows\Start Menu\Programs
%ProgramData%\Microsoft\Windows\Start Menu\Programs

I have confirmed these directories are correct for Windows 7, 8 & 10. 
