### PR TITLE
[WIP] Add macOS app icons support

### DIFF
--- a/appCache.js
+++ b/appCache.js
@@ -24,6 +24,7 @@ function setup (pluginContext) {
     includePath: resolvePaths(directories.appPath),
     excludePath: resolvePaths(directories.excludePath),
     excludeName: resolvePaths(directories.excludeName),
+    cwd,
   })
 
   return function run () {
@@ -47,8 +48,8 @@ function setup (pluginContext) {
 (() => {
   const cwd = __dirname
   const options = process.argv.slice(-1)[0] ? JSON.parse(process.argv.slice(-1)[0]) : {}
-  const {append} = options
-  const {directories} = options
+  const { append } = options
+  const { directories } = options
 
   setup({
     cwd: cwd,

--- a/lib/file.js
+++ b/lib/file.js
@@ -2,13 +2,27 @@ const fs = require('fs')
 const os = require('os')
 const path = require('path')
 const HOME_REGEX = new RegExp('^' + os.homedir())
-const plist = require('plist')
+const plist = require('simple-plist')
+const sha1 = require('sha1')
+const iconutil = require('iconutil')
+const mkdirp = require('mkdirp')
+const async = require('async')
+const exec = require('child_process').exec
+
+const iconutilQueue = async.queue(iconutil.toIconset, 20)
+
+const SYSTEM_DEFAULT_APP_ICNS =
+  '/System/Library/CoreServices/CoreTypes.bundle/Contents/Resources/GenericApplicationIcon.icns'
 
 class File {
-  constructor (name, dir) {
+  constructor (name, dir, options = {}) {
     this.name = name
     this.path = path.join(dir, name)
+    this.options = options
     this.stats = null
+    this.info = {}
+    this.iconPath = ''
+    this.loadInfo()
   }
 
   isViewable (exclude) {
@@ -45,17 +59,100 @@ class File {
     return !!(((mode >> 6) & 1) || (((mode << 3) >> 6) & 1) || (((mode << 6) >> 6) & 1))
   }
 
+  loadInfo () {
+    try {
+      if (this.isAppMac() && Object.keys(this.info).length === 0) {
+        //  macOS App
+        const infoPath = path.join(this.path, 'Contents', 'Info.plist')
+        this.info = plist.readFileSync(infoPath)
+        //  generate icon if it's not existed
+        this.iconPath = path.join('data', 'icons', `${this.name}-${sha1(this.path)}.png`)
+        const iconAbsPath = path.join(this.options.cwd || '', this.iconPath)
+        if (!fs.existsSync(iconAbsPath)) {
+          this.generateIcon(iconAbsPath)
+        }
+      }
+    } catch (err) {
+      console.trace(`Error when loading plist of ${this.name}: ${err}`)
+    }
+  }
+
+  findBestIcon (keys) {
+    //  Priorities: 128 > 256 > the largest
+    const regexNameParser = /x(\d+)(?:@(\w+))?/
+    const items = keys.map(key => {
+      const match = key.match(regexNameParser)
+      return match ? { size: Number(match[1]), scale: match[2], key } : { size: 0, key }
+    }).sort((a, b) => a.size - b.size)
+    const findBySize = (size) => items.find(item => item.size === size && item.scale !== '2x')
+    const preferedItem = findBySize(128) || findBySize(256) || items[items.length - 1]
+    return preferedItem.key
+  }
+
+  generateIcon (iconPath) {
+    try {
+      //  Create directory if it's not exist.
+      const basedir = path.dirname(iconPath)
+      if (!fs.existsSync(basedir)) {
+        mkdirp.sync(basedir)
+      }
+
+      if (this.info.CFBundleIconFile) {
+        //  Generate the icon from '.icns' file
+        let icnsPath = path.join(this.path, 'Contents', 'Resources', this.info.CFBundleIconFile)
+        if (this.info.CFBundleIconFile.indexOf('.') < 0) {
+          icnsPath = `${icnsPath}.icns`
+        }
+
+        if (fs.existsSync(icnsPath)) {
+          iconutilQueue.push(icnsPath, (err, icons) => {
+            if (err) {
+              console.error(`iconutil.toIconset(${icnsPath}): ${err}`)
+            } else {
+              fs.writeFileSync(iconPath, icons[this.findBestIcon(Object.keys(icons))])
+            }
+          })
+        } else {
+          //  Check for TIFF file
+          const tiffPath = `${icnsPath.substr(0, icnsPath.lastIndexOf('.'))}.tiff`
+          if (fs.existsSync(tiffPath)) {
+            //  Found TIFF file and convert it to PNG
+            exec(`sips -s format png '${tiffPath}' --out '${iconPath}'`,
+              (error, stdout, stderr) => { if (error) { console.error(stderr) } })
+          } else {
+            //  For the apps without icons, use system default app icon as last resort
+            if (fs.existsSync(SYSTEM_DEFAULT_APP_ICNS)) {
+              iconutilQueue.push(SYSTEM_DEFAULT_APP_ICNS, (err, icons) => {
+                if (err) {
+                  console.error(`iconutil.toIconset(${SYSTEM_DEFAULT_APP_ICNS}): ${err}`)
+                } else {
+                  fs.writeFileSync(iconPath, icons[this.findBestIcon(Object.keys(icons))])
+                }
+              })
+            } else {
+              console.error(`Cannot find '${icnsPath}' and no system default app icon available.`)
+            }
+          }
+        }
+      }
+    } catch (e) {
+      console.error(`Exception when generateIcon(${this.path}): ${e}`)
+    }
+  }
+
   title () {
     const fileName = this.name.split('.')[0]
     if (process.platform !== 'darwin' || !this.isApp()) {
       return fileName
     }
-    try {
-      const infoPath = path.join(this.path, 'contents', 'Info.plist')
-      const file = plist.parse(fs.readFileSync(infoPath).toString())
-      return file.CrAppModeShortcutName || file.CFBundleDisplayName || file.CFBundleName || fileName
-    } catch (e) {
-      return fileName
+    return this.info.CrAppModeShortcutName || this.info.CFBundleDisplayName || this.info.CFBundleName || fileName
+  }
+
+  icon () {
+    if (process.platform === 'darwin' && this.isApp()) {
+      return this.iconPath
+    } else {
+      return this.isDirectory() ? 'fa-folder' : 'fa-file'
     }
   }
 
@@ -75,7 +172,7 @@ class File {
 
   toJson () {
     return {
-      icon: this.isDirectory() ? 'fa-folder' : 'fa-file',
+      icon: this.icon(),
       title: this.title(),
       subtitle: this.relativePath(),
       value: this.relativePath(),

--- a/lib/finder.js
+++ b/lib/finder.js
@@ -8,7 +8,7 @@ class Finder {
 
   findIn (searchPath) {
     return new Promise((resolve, reject) => {
-      const file = new File(searchPath, '')
+      const file = new File(searchPath, '', this.options)
       file.getStats().then(() => {
         if (file.isBroken()) return resolve([])
         fs.readdir(searchPath, (err, fileNames) => {
@@ -20,7 +20,7 @@ class Finder {
       return fileNames.filter((file) => {
         return this.options.excludeName.indexOf(file) === -1
       }).map((fileName) => {
-        return new File(fileName, searchPath)
+        return new File(fileName, searchPath, this.options)
       }).filter((fileModel) => {
         return fileModel.isViewable(this.options.excludePath)
       })

--- a/package.json
+++ b/package.json
@@ -29,6 +29,9 @@
     "tape": "^4.6.0"
   },
   "dependencies": {
-    "plist": "^2.0.1"
+    "async": "^2.1.4",
+    "iconutil": "^1.0.1",
+    "sha1": "^1.1.1",
+    "simple-plist": "^0.2.1"
   }
 }

--- a/test/file.spec.js
+++ b/test/file.spec.js
@@ -1,0 +1,98 @@
+const describe = require('tape')
+const fs = require('fs')
+const path = require('path')
+const os = require('os')
+
+const File = require('../lib/file')
+
+class StubFile extends File {
+  isDirectory () {
+    return false
+  }
+  loadInfo () {
+    this.info = {}
+    this.iconPath = ''
+  }
+}
+
+describe('File.findBestIcon() should return size "128" if it exists', (assert) => {
+  const iconSetWithout2x = [
+    'icon_128x128.png',
+    'icon_16x16.png',
+    'icon_256x256.png',
+    'icon_32x32.png',
+    'icon_512x512.png',
+  ]
+  const iconSetWith2x = [
+    'icon_128x128@2x.png',
+    'icon_128x128.png',
+    'icon_16x16.png',
+    'icon_256x256.png',
+    'icon_32x32.png',
+    'icon_512x512.png',
+    'icon_16x16@2x.png',
+    'icon_256x256@2x.png',
+    'icon_32x32@2x.png',
+  ]
+
+  const f = new StubFile('Terminal.app', '/Applications/Utilities')
+  assert.equal(f.findBestIcon(iconSetWithout2x), 'icon_128x128.png')
+  assert.equal(f.findBestIcon(iconSetWith2x), 'icon_128x128.png')
+  assert.end()
+})
+
+describe('File.findBestIcon() should return size "256" if it doesn\'t exist and have 256', (assert) => {
+  const iconSetWithout128 = [
+    'icon_16x16.png',
+    'icon_256x256.png',
+    'icon_32x32.png',
+    'icon_512x512.png',
+  ]
+
+  const f = new StubFile('Terminal.app', '/Applications/Utilities')
+  assert.equal(f.findBestIcon(iconSetWithout128), 'icon_256x256.png')
+  assert.end()
+})
+
+describe('File.findBestIcon() should return largest size if no prefered size exists', (assert) => {
+  const iconSetWithout128and256 = [
+    'icon_16x16.png',
+    'icon_32x32.png',
+    'icon_512x512.png',
+    'icon_16x16@2x.png',
+    'icon_32x32@2x.png',
+  ]
+
+  const f = new StubFile('Terminal.app', '/Applications/Utilities')
+  assert.equal(f.findBestIcon(iconSetWithout128and256), 'icon_512x512.png')
+  assert.end()
+})
+
+//  Do the real world test on macOS system
+if (process.platform === 'darwin') {
+  const testCwd = path.join(os.tmpdir(), 'test', 'file')
+
+  describe('File.constructor() should initialize all the members', (assert) => {
+    //  Using system app 'Terminal.app' for the testing.
+    const app = new File('Terminal.app', '/Applications/Utilities', { cwd: testCwd })
+
+    assert.equal(app.name, 'Terminal.app')
+    assert.equal(app.path, '/Applications/Utilities/Terminal.app')
+    assert.equal(app.options.cwd, testCwd)
+    assert.notEqual(app.info, {})
+    assert.ok(app.info.CFBundleIconFile)
+    assert.ok(app.iconPath.indexOf('data/icons/Terminal.app-') === 0,
+      'Testing whether contains generated icon path')
+    assert.end()
+  })
+
+  describe('File.generateIcon() should generate the icons', (assert) => {
+    const app = new File('Terminal.app', '/Applications/Utilities', { cwd: testCwd })
+    //  Wait a little bit for the icon generation, 1 second should be enough for a single icon
+    setTimeout(() => {
+      const iconAbsPath = path.join(testCwd, app.iconPath)
+      assert.true(fs.existsSync(iconAbsPath), 'Testing whether icon has been generated or not.')
+      assert.end()
+    }, 1000)
+  })
+}

--- a/test/fileFinder.spec.js
+++ b/test/fileFinder.spec.js
@@ -6,6 +6,10 @@ class StubFile extends File {
   isDirectory () {
     return false
   }
+  loadInfo () {
+    this.info = {}
+    this.iconPath = ''
+  }
 }
 
 class StubFinder {

--- a/test/index.js
+++ b/test/index.js
@@ -1,2 +1,3 @@
 require('./appFinder.spec')
 require('./fileFinder.spec')
+require('./file.spec')


### PR DESCRIPTION
Implement loading macOS app icons by reading `Info.plist` to get icon file, and convert to PNG by `iconutil` tool.

Replacing the dependency `plist` with `simple-plist` to support both `text plist` files and `binary plist` files.

After the `Info.plist` loaded, it uses `CFBundleIconFile` to locate the icon.

PNG files are converted from `.icns` by `iconutil`, which use external `iconutil` executable on macOS to do the conversion. To avoid `EMFILE: too many open files` problem, `async.queue` is used to limit the concurrent `iconutil` process.

The `.icns` usually contains multiple icons in various sizes, this implementation will choose the icon based on the priorities: `128` > `256` > the largest icon.

It will also handle the `.tiff` file if no `.icns` exists, the `.tiff` file will be converted to PNG file and stored to the cache by `sip` command line tool.

For those apps without icons, the system default app icon `/System/Library/CoreServices/CoreTypes.bundle/Contents/Resources/GenericApplicationIcon.icns` will be used if it exists.

The PNG files of app icons are generated and stored in `${PLUGIN_DIR}/data/icons/` directory, with the file name `${APP_NAME}-${sha1(APP_PATH)}`. Hashing the path to avoid the duplication, and with app name in it to make it easier to identify which app it's belong to.

*Still working in progress.*

![2017-02-01 01 00 46](https://cloud.githubusercontent.com/assets/6299096/22467768/fd7bf010-e819-11e6-95cf-48226394bb79.png)

Signed-off-by: Tao Wang <twang2218@gmail.com>