### PR TITLE
Remove dead dependencies.

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,10 +30,7 @@
   },
   "dependencies": {
     "app2png": "^1.0.0",
-    "async": "^2.1.4",
     "fuzzyfind": "^2.0.0",
-    "iconutil": "^1.0.2",
-    "mkdirp": "^0.5.1",
-    "simple-plist": "^0.2.1"
+    "mkdirp": "^0.5.1"
   }
 }


### PR DESCRIPTION
Reviewer: @twang2218 

Looks like we forgot to remove some of the dependencies when we abstracted out the app2png stuff.