### PR TITLE
Change osx app query to be non-language specific.

### DIFF
--- a/adapters/osx-mdfind/index.js
+++ b/adapters/osx-mdfind/index.js
@@ -2,6 +2,8 @@ const fuzzyfind = require('fuzzyfind')
 const Adapter = require('../../lib/adapter')
 const mdfind = require('./mdfind')
 
+const appQuery = '(kMDItemContentType=com.apple.application-* || kMDItemContentType=com.apple.systempreference.prefpane)'
+
 class MDFind extends Adapter {
   findFiles (query) {
     const { filePath, excludeName, excludePath } = this.env.directories
@@ -27,7 +29,7 @@ class MDFind extends Adapter {
       include: appPath,
       exclude: excludeName.concat(excludePath),
     }
-    return mdfind(`(kind:app OR kind:pref) ${query}`, options).then((files) => {
+    return mdfind(appQuery, options).then((files) => {
       return fuzzyfind(query, files, {
         accessor: function (obj) {
           return obj.name + obj.path
@@ -52,7 +54,7 @@ class MDFind extends Adapter {
       exclude: excludeName.concat(excludePath),
     }
 
-    return mdfind('kind:app OR kind:pref', options)
+    return mdfind(appQuery, options)
       .then(apps => this.cacheIcons(apps))
       .then(apps => apps.map(app => app.toJson()))
   }

--- a/readme.md
+++ b/readme.md
@@ -71,6 +71,9 @@ If you want to overwrite the directories you can.
 
 ### Testing
 
+WARNING: If you are on MacOS, you cannot test this plugin where Zazu installs
+it, since `~/.zazu` as a hidden folder is ignored.
+
 Run tests in current system environment:
 
 ```bash

--- a/test/adapters/osx-mdfind.spec.js
+++ b/test/adapters/osx-mdfind.spec.js
@@ -45,12 +45,12 @@ if (process.platform === 'darwin') {
         return adapter.findApps('apple')
       })
       .then(apps => {
-        assert.true(apps && apps.length === 1, 'findApps("apple") should be able to return result')
+        assert.true(apps && apps.length >= 1, 'findApps("apple") should be able to return result')
         assert.equal(apps[0].title, 'Text Apple', 'findApps("apple") should return "Text Apple" app')
         return adapter.findApps('orange')
       })
       .then(apps => {
-        assert.true(apps && apps.length === 1, 'findApps("orange") should be able to return the result')
+        assert.true(apps && apps.length >= 1, 'findApps("orange") should be able to return the result')
         assert.equal(apps[0].title, 'Binary Orange', 'findApps("orange") should return "Binary Orange" app')
         assert.end()
       })


### PR DESCRIPTION
The issue is on mac, when the language isn't english, that users cannot find apps. The change is that we no longer use `kind:app` instead we use the long canonical form `com.apple.application-*`.

Changes:
* The long canonical form includes slightly more apps (~10 more on my computer)
* We no longer use `mdfind` to pre-filter based on a name, mostly because I couldn't figure out the syntax, so we rely more on `fuzzyfind` so we sometimes get more results (see the test changes) (which might be a good thing!)

reviewer: @twang2218 

cc:@chrishelgert and @danielbayerlein